### PR TITLE
output shp fields now correctly represented

### DIFF
--- a/sequencer/Sequencer.py
+++ b/sequencer/Sequencer.py
@@ -172,7 +172,28 @@ class Sequencer(object):
         # Write the shapefiles to path
         nx.write_shp(self.networkplan.network, os.path.join(path, out_shp))
         # Write the csv to path
-        self.output_frame.to_csv(os.path.join(path, out_results), index=False, na_rep='NaN')
+        cast = {
+                'Sequence..Vertex.id'            : int,
+                'Sequence..Root.vertex.id'       : int ,
+                'Sequence..Upstream.id'          : int,
+                'Sequence..Far.sighted.sequence' : int}
+        
+        for k,v in cast.iteritems():
+            self.output_frame[k] = self.output_frame[k].fillna(-5059030070).astype(v)        
+        self.output_frame.to_csv(os.path.join(path, 'temp.csv'), index=False, na_rep='NaN')
+        
+        with open(os.path.join(path, 'temp.csv')) as f:
+            buff = f.read()
+            while True:
+                idx = buff.find('-5059030070')
+                if idx != -1:
+                    buff = buff.replace('-5059030070', 'NaN', idx)
+                else:
+                    break
+
+        with open(os.path.join(path, out_results), 'w') as f:
+            f.write(buff)
+        os.remove(os.path.join(path, 'temp.csv'))
         
         # Trash the node shp files
         [os.remove(os.path.join(os.path.join(path, out_shp), x)) 


### PR DESCRIPTION
Must explicitly cast NumPy types back to native python types for network.write_shp to output edges correctly
![screen shot 2014-09-15 at 10 23 44 am](https://cloud.githubusercontent.com/assets/4959802/4272803/4fc7fa40-3ce5-11e4-9bb6-d15ce5f34d4b.png)

(closes issue #31)
